### PR TITLE
v0.0.2 - Security hardening

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 serde-hex = { version = "0.1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 
-socketcan = { version = "1.7.0", optional = true }
+socketcan = { git = "https://github.com/mdegans/socketcan-rs.git", rev = "6941caafb12dcb272dc78c1697c16de4155bc8a2", optional = true }
 embedded-can = { version = "0.4.1", optional = true }
 
 clap = { version = "4.0.23", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jeep"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 authors = [
     "Michael de Gans <michael.john.degans@gmail.com>",

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you find a security vulnerability, please [email me](mailto:michael.john.degans@gmail.com).
+If you wish to encrypt the email, my GPG public key is [here](https://github.com/mdegans.gpg).


### PR DESCRIPTION
This addresses a vulnerability in an old version of a `nix` crate dependency pinned in the `1.7.0` crates.io version of `socketcan` upstream.

It's unlikely that either `socketcan` or the `jeep` crate are exploitable by this, but updating the dependency rules it out as being used as part of an exploit chain, and it shuts dependabot up.